### PR TITLE
Enable a unique filename per case

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       shell: bash
 
 ##################################
-# TEST HDF5-iotest
+# BUILD HDF5-iotest
 ##################################
 
     - name: test hdf5-iotest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         sudo apt-get install -qq libhdf5-mpi-dev
         # Set env vars
         echo "CC=mpicc" >> $GITHUB_ENV
-        echo "CPPFLAGS=-I/usr/include/hdf5/mpich" >> $GITHUB_ENV
+#       echo "CPPFLAGS=-I/usr/include/hdf5/mpich" >> $GITHUB_ENV
 
  # Checks-out the repository under $GITHUB_WORKSPACE so the job can access it.
     - name: Get Sources
@@ -48,6 +48,7 @@ jobs:
 
     - name: configure hdf5-iotest
       run: |
+        find /usr/include -iname "hdf5.h"
         ./autogen.sh
         mkdir build; cd build
         ../configure --prefix=$GITHUB_WORKSPACE/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ on:
     branches: [ master ]
 
 # A workflow run is made up of one or more jobs that
-# can run sequentially or in parallel
+# can run sequentially or in parallel 
 jobs:
   # This workflow contains a single job called "build"
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,71 @@
+name: hdf5-iotest
+
+# Controls when the action will run. 
+#Triggers the workflow on push or pull requests.
+#on: 
+#  push:
+#    branches: [ master ]
+#  pull_request:
+#    branches: [ master ]
+#on: 
+#  push:
+#  pull_request:
+on: 
+  push:
+    branches: [ actions ]
+  pull_request:
+    branches: [ actions ]
+
+# A workflow run is made up of one or more jobs that
+# can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    strategy:
+      matrix:
+        name: ["Ubuntu Latest GCC"]
+        include:
+          - name: "Ubuntu Latest GCC"
+            artifact: "Linux.tar.xz"
+            os: ubuntu-latest
+
+    name: ${{ matrix.name }}
+    # The type of runner that the job will run on.
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'skip-ci')"
+
+    # Steps represent a sequence of tasks that will be executed 
+    # as part of the job.
+    steps:
+    - name: Install Dependencies (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get install -qq mpich
+        sudo apt-get install -qq libhdf5-mpi-dev
+        # Set env vars
+        echo "CC=mpicc" >> $GITHUB_ENV
+
+ # Checks-out the repository under $GITHUB_WORKSPACE so the job can access it.
+    - name: Get Sources
+      uses: actions/checkout@v2
+
+##################################
+# CONFIGURE (Autotools)
+##################################
+
+    - name: configure hdf5-iotest
+      run: |
+        mkdir build; cd build
+        ../configure --prefix=$GITHUB_WORKSPACE/build
+      shell: bash
+
+##################################
+# TEST HDF5-iotest
+##################################
+
+    - name: test hdf5-iotest
+      run: |
+        cd build
+        make 
+        make install
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         sudo apt-get install -qq libhdf5-mpich-dev
         # Set env vars
         echo "CC=mpicc" >> $GITHUB_ENV
-#       echo "CPPFLAGS=-I/usr/include/hdf5/openmpi" >> $GITHUB_ENV
+#       echo "CPPFLAGS=-I/usr/include/hdf5/mpich" >> $GITHUB_ENV
 
  # Checks-out the repository under $GITHUB_WORKSPACE so the job can access it.
     - name: Get Sources

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,11 @@ jobs:
     - name: Install Dependencies (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get install -qq mpich
+        sudo apt-get install -qq openmpi
         sudo apt-get install -qq libhdf5-mpi-dev
         # Set env vars
         echo "CC=mpicc" >> $GITHUB_ENV
-#       echo "CPPFLAGS=-I/usr/include/hdf5/mpich" >> $GITHUB_ENV
+#       echo "CPPFLAGS=-I/usr/include/hdf5/openmpi" >> $GITHUB_ENV
 
  # Checks-out the repository under $GITHUB_WORKSPACE so the job can access it.
     - name: Get Sources

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         # Set env vars
         echo "CC=mpicc" >> $GITHUB_ENV
         echo "CPPFLAGS=-I/usr/include/hdf5/mpich" >> $GITHUB_ENV
-        echo "LDFLAGS=-L/usr/lib" >> $GITHUB_ENV
+        echo "LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/mpich" >> $GITHUB_ENV
 
  # Checks-out the repository under $GITHUB_WORKSPACE so the job can access it.
     - name: Get Sources

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,9 @@ name: hdf5-iotest
 #  pull_request:
 on: 
   push:
-    branches: [ actions ]
+    branches: [ master ]
   pull_request:
-    branches: [ actions ]
+    branches: [ master ]
 
 # A workflow run is made up of one or more jobs that
 # can run sequentially or in parallel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         sudo apt-get install -qq libhdf5-mpich-dev
         # Set env vars
         echo "CC=mpicc" >> $GITHUB_ENV
-#       echo "CPPFLAGS=-I/usr/include/hdf5/mpich" >> $GITHUB_ENV
+        echo "CPPFLAGS=-I/usr/include/hdf5/mpich" >> $GITHUB_ENV
 
  # Checks-out the repository under $GITHUB_WORKSPACE so the job can access it.
     - name: Get Sources

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,6 @@ jobs:
 
     - name: configure hdf5-iotest
       run: |
-        find /usr/ -iname "libhdf5*"
         ./autogen.sh
         mkdir build; cd build
         ../configure --prefix=$GITHUB_WORKSPACE/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
         # Set env vars
         echo "CC=mpicc" >> $GITHUB_ENV
         echo "CPPFLAGS=-I/usr/include/hdf5/mpich" >> $GITHUB_ENV
+        echo "LDFLAGS=-L/usr/lib" >> $GITHUB_ENV
 
  # Checks-out the repository under $GITHUB_WORKSPACE so the job can access it.
     - name: Get Sources
@@ -48,7 +49,7 @@ jobs:
 
     - name: configure hdf5-iotest
       run: |
-        find /usr/include -iname "hdf5.h"
+        find /usr/ -iname "libhdf5*"
         ./autogen.sh
         mkdir build; cd build
         ../configure --prefix=$GITHUB_WORKSPACE/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,8 @@ jobs:
     - name: Install Dependencies (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get install -qq openmpi
-        sudo apt-get install -qq libhdf5-mpi-dev
+        sudo apt-get install -qq mpich
+        sudo apt-get install -qq libhdf5-mpich-dev
         # Set env vars
         echo "CC=mpicc" >> $GITHUB_ENV
 #       echo "CPPFLAGS=-I/usr/include/hdf5/openmpi" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
         sudo apt-get install -qq libhdf5-mpi-dev
         # Set env vars
         echo "CC=mpicc" >> $GITHUB_ENV
+        echo "CPPFLAGS=-I/usr/include/hdf5/mpich" >> $GITHUB_ENV
 
  # Checks-out the repository under $GITHUB_WORKSPACE so the job can access it.
     - name: Get Sources

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,14 +2,6 @@ name: hdf5-iotest
 
 # Controls when the action will run. 
 #Triggers the workflow on push or pull requests.
-#on: 
-#  push:
-#    branches: [ master ]
-#  pull_request:
-#    branches: [ master ]
-#on: 
-#  push:
-#  pull_request:
 on: 
   push:
     branches: [ master ]
@@ -17,7 +9,7 @@ on:
     branches: [ master ]
 
 # A workflow run is made up of one or more jobs that
-# can run sequentially or in parallel 
+# can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:
@@ -55,6 +47,7 @@ jobs:
 
     - name: configure hdf5-iotest
       run: |
+        ./autogen.sh
         mkdir build; cd build
         ../configure --prefix=$GITHUB_WORKSPACE/build
       shell: bash

--- a/README.org
+++ b/README.org
@@ -7,7 +7,7 @@
 
 * Description
 
-This is a simple I/O performance tester for HDF5.  (See also [[https://github.com/ornladios/ADIOS2/tree/master/source/utils/adios_iotest][ADIOS IOTEST]].) It's
+This is a simple I/O performance tester for HDF5.  (See also [[https://github.com/ornladios/ADIOS2/tree/master/source/utils/adios_iotest][ADIOS IOTEST]].) Its
 purpose is to assess the /performance variability/ of a set of logically
 equivalent HDF5 representations of a common pattern. The test repeatedly writes
 (and reads) in parallel a set of 2D array variables in a tiled fashion, over a
@@ -54,7 +54,7 @@ stop
 A configuration file (see below) is used to control parameters such as the
 number of steps, the count and shape of the 2D array variables, etc. (See
 section [[sec:parameters]].) The test then uses between 48 and 192 different
-combinations of up to 7 internal parameter (see section [[sec:internal-parameters]])
+combinations of up to 7 internal parameters (see section [[sec:internal-parameters]])
 to configure the HDF5 library and output, to perform write and read operations,
 and to report certain timings. (The number of combinations is different for
 sequential and parallel runs, and depends on other choices.)
@@ -67,7 +67,7 @@ is the proverbial "getting off on the wrong foot."
 
 * Installation
 
-While it can be build manually, we recommend building =hdf5_iotest= from [[https://computing.llnl.gov/projects/spack-hpc-package-manager][Spack]].
+While it can be built manually, we recommend building =hdf5_iotest= from [[https://computing.llnl.gov/projects/spack-hpc-package-manager][Spack]].
 
 1. Create a new Spack package
    #+begin_src sh
@@ -241,7 +241,7 @@ The following configuration parameters are supported.
     alignment-increment = 1
     #+end_src
 
-  By default there are no alignment restrictions in effect, and only
+  By default, there are no alignment restrictions in effect, and only
   increments greater than 1 have any effect.
 
 - Alignment Threshold :: The minimum object size (in bytes) for which alignment
@@ -284,7 +284,7 @@ The following configuration parameters are supported.
  hdf5-file = hdf5_iotest.h5
     #+end_src
 
-- Results File :: When running HDF5 I/O test, certain metrics are printed to
+- Results File :: When running the HDF5 I/O test, certain metrics are printed to
                   =stdout=. To simplify the analysis of results from multiple
                   runs, they are also written to a CSV file whose name is
                   configurable.
@@ -305,7 +305,7 @@ Currently, the I/O test varies the following parameters:
 - Storage Layout :: The dataset storage layout in the HDF5 file can be chunked
   or contiguous (or compact or virtual or user-defined).
 - Alignment :: HDF5 objects greater than or equal to an alignment threshold can
-  be aligned on addresses which are a multiple of a certain increment.
+  be aligned on addresses that are a multiple of a certain increment.
 - Lower Library Version Bound  :: The HDF5 library can be configured to use the
   earliest or latest available file format micro-versions when generating
   objects.

--- a/README.org
+++ b/README.org
@@ -280,6 +280,8 @@ The following configuration parameters are supported.
 
 - HDF5 Output File Name :: The default HDF5 output file name is
      =hdf5_iotest.h5=. Use this parameter to select a different name.
+     **Note**: The character "#" in the filename is reserved for creating an HDF5 
+     with the "#" replaced with the accumulated case number, for example *hdf5_iotest.#.h5*.
     #+begin_src conf-unix :noweb-ref hdf5-iotest-conf
  hdf5-file = hdf5_iotest.h5
     #+end_src

--- a/README.org
+++ b/README.org
@@ -140,7 +140,7 @@ make install
 
 =hdf5_iotest= accepts a single argument, the name of a configuration file. If no
 configuration file name is provided, it looks for a configuration named
-=hdf5-iotest.ini= in the current working directory.
+=hdf5_iotest.ini= in the current working directory.
 
 #+begin_src sh
 hdf5_iotest [INI file]

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -73,6 +73,11 @@ int check_options
     pconfig->split = (unsigned int) atol(value);
   } else if (MATCH(section, "hdf5-file")) {
     strncpy(pconfig->hdf5_file, value, PATH_MAX-1);
+    /* Enable individual output HDF5 files per case, denoted by a "#" in the filename */
+    if(strstr(pconfig->hdf5_file, "#") != NULL)
+      {
+        pconfig->HDF5perCase = 1;
+      }
   } else if (MATCH(section, "csv-file")) {
     strncpy(pconfig->csv_file, value, PATH_MAX-1);
   } else if (MATCH(section, "restart")) {

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -48,6 +48,7 @@ typedef struct
   unsigned int  restart;
   unsigned int  split;
   unsigned int  one_case;
+  unsigned int  HDF5perCase;
 } configuration;
 
 extern int handler(void* user,

--- a/src/hdf5_iotest.c
+++ b/src/hdf5_iotest.c
@@ -61,6 +61,8 @@ int main(int argc, char* argv[])
   MPI_Comm_size(MPI_COMM_WORLD, &size);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
+  /* Turn off buffering of stdout */
+  setbuf(stdout, NULL);
 
   if (rank == 0) /* rank 0 reads and checks the config. file */
     {

--- a/src/hdf5_iotest.c
+++ b/src/hdf5_iotest.c
@@ -64,20 +64,24 @@ int main(int argc, char* argv[])
       uuid_t uuid;
       /* sensible defaults */
       config.rank = 4;
+      config.hdf5_file[0] = '\0';
+      config.csv_file[0] = '\0';
 
       if (ini_parse(ini, handler, &config) < 0)
         {
           printf("Can't load '%s'\n", ini);
           return 1;
         }
-
-      uuid_generate_time_safe(uuid);
-      uuid_unparse_lower(uuid, config.csv_file);
-      config.csv_file[36] = '.';
-      config.csv_file[37] = 'c';
-      config.csv_file[38] = 's';
-      config.csv_file[39] = 'v';
-      config.csv_file[40] = '\0';
+      if (config.csv_file[0] == '\0')
+        {
+          uuid_generate_time_safe(uuid);
+          uuid_unparse_lower(uuid, config.csv_file);
+          config.csv_file[36] = '.';
+          config.csv_file[37] = 'c';
+          config.csv_file[38] = 's';
+          config.csv_file[39] = 'v';
+          config.csv_file[40] = '\0';
+        }
 
       printf("Output: %s\n", config.csv_file);
     }

--- a/src/read_test.c
+++ b/src/read_test.c
@@ -23,6 +23,7 @@
 void read_test
 (
  configuration* pconfig,
+ char * hdf5_filename,
  int size,
  int rank,
  int my_proc_row,
@@ -81,8 +82,7 @@ void read_test
   printf("\nWARNING: Data verification enabled. Timings will be distorted!!!\n");
 #endif
 
-
-  assert((file = H5Fopen(pconfig->hdf5_file, H5F_ACC_RDONLY, fapl)) >= 0);
+  assert((file = H5Fopen(hdf5_filename, H5F_ACC_RDONLY, fapl)) >= 0);
 
   switch (pconfig->rank)
     {

--- a/src/read_test.h
+++ b/src/read_test.h
@@ -20,6 +20,7 @@
 extern void read_test
 (
  configuration* pconfig,
+ char * hdf5_filename,
  int size,
  int rank,
  int my_proc_row,

--- a/src/utils.c
+++ b/src/utils.c
@@ -42,7 +42,8 @@ void print_results
  )
 {
   hid_t file;
-  hsize_t fsize;
+  hsize_t fsize,fsize_units;
+
   unsigned majnum, minnum, relnum;
   char version[16];
   assert(H5get_libversion(&majnum, &minnum, &relnum) >= 0);
@@ -53,8 +54,18 @@ void print_results
   assert(H5Fclose(file) >= 0);
 
   /* write summary to the console */
-  printf("Wall clock [s]:\t\t%.2f\n", wall_time);
-  printf("File size [B]:\t\t%.0f\n", (double)fsize);
+  printf("Wall clock  [s]:\t\t%.2f\n", wall_time);
+
+  static const char *UNIT[] = { "B", "kiB", "MiB", "GiB", "TiB", "PiB", "EiB" };
+  hsize_t cnt = 0;
+  hsize_t rem = 0;
+  fsize_units=fsize;
+  while (fsize_units >= 1024 && cnt < (sizeof UNIT / sizeof *UNIT)) {
+    rem = (fsize_units % 1024);
+    fsize_units /= 1024;
+    cnt++;
+  }
+  printf("File size [%s]:\t\t%.1f\n", UNIT[cnt], (float)fsize_units + (float)rem / 1024.0);
 
   { /* write results to the CSV file */
     FILE *fptr = fopen(pconfig->csv_file, "a");

--- a/src/utils.c
+++ b/src/utils.c
@@ -60,8 +60,8 @@ void print_results
   hsize_t cnt = 0;
   hsize_t rem = 0;
   fsize_units=fsize;
-  while (fsize_units >= 1024 && cnt < (sizeof UNIT / sizeof *UNIT)) {
-    rem = (fsize_units % 1024);
+  while (fsize_units >= 1024 && cnt < (sizeof(UNIT) / sizeof(*UNIT))) {
+    rem = fsize_units % 1024;
     fsize_units /= 1024;
     cnt++;
   }

--- a/src/utils.c
+++ b/src/utils.c
@@ -38,6 +38,7 @@ void create_output_file(const char* fname)
 void print_results
 (
  configuration* pconfig,
+ char*          hdf5_filename,
  double         wall_time,
  timings*       pts
  )
@@ -58,7 +59,7 @@ void print_results
       char digit = 0;
       char digits[18];
       strcpy(command, "du --apparent-size -cb ");
-      strcat(command, pconfig->hdf5_file);
+      strcat(command, hdf5_filename);
       strcat(command, "*.h5 | tail -1 | sed 's/[^0-9]//g'");
 
       if (0 == (fpipe = (FILE*)popen(command, "r")))
@@ -78,7 +79,7 @@ void print_results
     } 
   else 
     {
-      assert((file = H5Fopen(pconfig->hdf5_file, H5F_ACC_RDONLY, H5P_DEFAULT)) >= 0);
+      assert((file = H5Fopen(hdf5_filename, H5F_ACC_RDONLY, H5P_DEFAULT)) >= 0);
       assert(H5Fget_filesize(file, &fsize) >= 0);
       assert(H5Fclose(file) >= 0);
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -62,7 +62,8 @@ void get_timings
 
 void print_results
 (
- configuration* pconfig,
+ configuration* pconfig, 
+ char*          hdf5_filename,
  double         wall_time,
  timings*       pts
  );

--- a/src/write_test.c
+++ b/src/write_test.c
@@ -23,6 +23,7 @@
 void write_test
 (
  configuration* pconfig,
+ char * hdf5_filename,
  int size,
  int rank,
  int my_proc_row,
@@ -88,7 +89,7 @@ void write_test
 #endif
 
   *create_time -= MPI_Wtime();
-  assert((file = H5Fcreate(pconfig->hdf5_file, H5F_ACC_TRUNC, fcpl, fapl))
+  assert((file = H5Fcreate(hdf5_filename, H5F_ACC_TRUNC, fcpl, fapl))
          >= 0);
   *create_time += MPI_Wtime();
 

--- a/src/write_test.h
+++ b/src/write_test.h
@@ -20,6 +20,7 @@
 extern void write_test
 (
  configuration* pconfig,
+ char * hdf5_filename,
  int size,
  int rank,
  int my_proc_row,


### PR DESCRIPTION
Darshan can produce a summary report on a per-file basis, so enable creating a unique HDF5 filename for each case.