### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -120,11 +120,15 @@ While it can be built manually, we recommend building =hdf5_iotest= from [[https
        def test(self):
            pass
    #+end_src
-3. Test the configuration via
+3. Show the explicit dependency configuration (libraries, versions, compiler, architecture, etc. ) via
    #+begin_src sh
    spack spec hdf5iotest
    #+end_src
    Sample output can be found in the [[sec:spack-spec-out][appendix]].
+4. Install the hdf5iotest package and all dependencies
+   #+begin_src sh
+   spack install hdf5iotest
+   #+end_src
 
 ** Installation w/o Spack
 You need a working installation of parallel HDF5 (which depends on MPI).


### PR DESCRIPTION
The existing Spack install instructions do not build or install anything.  I'm adding a spack install command to do that.