### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -109,6 +109,7 @@ While it can be built manually, we recommend building =hdf5_iotest= from [[https
        depends_on('m4',       type='build')
        depends_on('mpi')
        depends_on('hdf5')
+       depends_on('util-linux-uuid')
 
        def configure_args(self):
            args = []


### PR DESCRIPTION
Adding dependency `util-linux-uuid` was sufficient to fix missing uuid.h on final build of hdf5iotest on a fresh Ubuntu 22.04 system.   This will not fix the same build failure following the non-Spack install instructions.